### PR TITLE
Exclude certain files from calculated codecoverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,11 @@ jacocoTestReport {
         classDirectories = files(classDirectories.files.collect {
             fileTree(dir: it,
                     exclude: ['**/*Main*.*',
-                              '**/*PredefinedAlphabetStrings*.*'])
+                              '**/*GraphMLConverter*.*',
+                              '**/*MatrixPrinter*.*',
+                              '**/*RandomGenerator*.*',
+                              '**/*DefaultRandomGenerator*.*',
+                              '**/*SeededRandomGenerator*.*',])
         })
     }
 }


### PR DESCRIPTION
Certain files are now excluded from the calculated code coverage, for various reasons

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>