### PR TITLE
Codecov is now just to report the level of code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,8 +4,8 @@ coverage:
     project:
       default:
         # basic
-        target: 70
-        threshold: 15
+        target: 0
+        threshold: 100
         base: auto 
 
 coverage:
@@ -13,6 +13,6 @@ coverage:
     patch:
       default:
         # basic
-        target: 70
-        threshold: 15
+        target: 0
+        threshold: 100
         base: auto 


### PR DESCRIPTION
This **should** keep Codecov from ever failing a PR for weird reasons.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>